### PR TITLE
Feat: Preserve query params

### DIFF
--- a/src/lib/build-wms-layer.js
+++ b/src/lib/build-wms-layer.js
@@ -2,9 +2,14 @@ import buildGeoserverUrl from './build-geoserver-url'
 
 const defaultUrl = process.env.VUE_APP_GEOSERVER_BASE_URL
 
-export default ({ url = defaultUrl, id, layer, style = '', paint = {}, tileSize = 256 }) => {
+export default ({ url: rawUrl = defaultUrl, id, layer, style = '', paint = {}, tileSize = 256 }) => {
+
+  const url = new URL(rawUrl)
+  const searchParamEntries = url.searchParams.entries()
+  const searchParamsObject = Object.fromEntries(searchParamEntries)
+
   const tile = buildGeoserverUrl({
-    url,
+    url: url.origin + url.pathname,
     service: 'WMS',
     request: 'GetMap',
     layers: layer,
@@ -16,6 +21,7 @@ export default ({ url = defaultUrl, id, layer, style = '', paint = {}, tileSize 
     bbox: '{bbox-epsg-3857}',
     format: 'image/png',
     encode: false,
+    ...searchParamsObject,
   })
 
   return {


### PR DESCRIPTION
Before, it was not possible to add query params to server urls in the
config file. Now the query params are preserved and merged with the
other paramters.

This is implemented by converting the raw url (containing the query
params) into an URL object, extracting the query params and merging it
with the other config variables. The query params are added last, this
allows for overwriting the default config.
