### PR TITLE
Feat/rwsviewers 38 download wms layer

### DIFF
--- a/src/lib/build-download-url.js
+++ b/src/lib/build-download-url.js
@@ -1,24 +1,52 @@
 import {
+  OWS_LAYER_TYPE,
+  WMS_LAYER_TYPE,
+} from '~/lib/constants'
+import {
   createDownloadFilter,
   createDownloadParameters,
-  isWcsLayer,
-  isWfsLayer,
+  hasWcsTypeUrl,
+  hasWfsTypeUrl,
+  hasWmsTypeUrl,
 } from '~/lib/download-helpers'
 
-function buildDownloadUrl({ layerData = {}, coordinates = '' }) {
-  const { downloadUrl } = layerData
-  const isWcsType = isWcsLayer(layerData)
-  const isWfsType = isWfsLayer(layerData)
-  const outputType = isWcsType && 'tiff' || isWfsType && 'csv'
+function getDownloadUrl(layerData = {}) {
+  const { downloadUrl, layer, url } = layerData
+  const isWcsType = hasWcsTypeUrl(layerData)
+  const isWfsType = hasWfsTypeUrl(layerData)
+  const isWmsType = hasWmsTypeUrl(layerData)
+
+  if (!isWcsType && !isWfsType && !isWmsType) {
+    console.warn('No valid type present in `downloadUrl` or `url` for layer: ', layer)
+    return null
+  }
+
+  if (isWcsType || isWfsType) {
+    return downloadUrl
+  }
+
+  if (isWmsType) {
+    return url.replace(`/${ WMS_LAYER_TYPE }`, `/${ OWS_LAYER_TYPE }`)
+  }
+}
+
+function getUrlAndOutputType({ layer = {}, coordinates = '' }) {
+  const url = getDownloadUrl(layer)
+
+  const isWcsType = hasWcsTypeUrl(layer)
+  const isWfsType = hasWfsTypeUrl(layer)
+  const isWmsType = hasWmsTypeUrl(layer)
+
+  const outputType = isWcsType && 'tiff' || isWfsType && 'csv' || isWmsType && 'csv'
   const filter = createDownloadFilter(coordinates)
-  const params = createDownloadParameters({ layerData, filter })
+  const params = createDownloadParameters({ layerData: layer, filter })
 
   return {
-    url: `${ downloadUrl }?${ params }`,
+    url: `${ url }?${ params }`,
     fileType: outputType,
   }
 }
 
 export default function(layerData = [], coordinates = '') {
-  return layerData.map(layer => buildDownloadUrl({ layerData: layer, coordinates }))
+  return layerData.map(layer => getUrlAndOutputType({ layer, coordinates }))
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,3 +1,11 @@
 export const VALID_VIEWER_CONFIGS = require('../../public/data/available-configs.json')
 
 export const CATEGORIES = require('../../public/data/app.json').categories
+
+export const COORDINATES_HANDLE = '[[COORDINATES]]'
+
+// Layer types
+export const OWS_LAYER_TYPE = 'ows'
+export const WCS_LAYER_TYPE = 'wcs'
+export const WMS_LAYER_TYPE = 'wms'
+export const WFS_LAYER_TYPE = 'wfs'

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -156,7 +156,7 @@
       },
 
       allUrlsAreValid() {
-        return this.selectedLayerData.every(({ downloadUrl }) => Boolean(downloadUrl))
+        return this.selectedLayerData.every((layer) => Boolean(layer.downloadUrl) || Boolean(layer.url))
       },
 
       buttonText() {


### PR DESCRIPTION
This pull request includes:
- If no `downloadUrl` is present for a layer, use `url` (if available). Then treat this url as a WFS layer type.
  - If no valid type (`wcs`, `wms`, `wfs`) is found in either `downloadUrl` or `url`, `console.warn` this with the layer name.
- Moved some `const`'s from `download-helpers.js` to `constants.js`.