### PR TITLE
feat: redirect to primary domain & proxy kaartenbak api

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,16 @@
   publish = "dist/"
 
 [[redirects]]
+  from = "https://rws-viewer.netlify.app/*"
+  to = "https://viewer.openearth.nl/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/api/*"
+  to = "https://kaartenbak.netlify.app/api/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
Resolves [RWSVIEWERS-182](https://issuetracker.deltares.nl/browse/RWSVIEWERS-182)

* Example of API request proxy: https://deploy-preview-62--rws-viewer.netlify.app/api/factsheet?id=123086159&format=html
* Redirect to primary domain will only work (and can only be tested) once merged to main and deployed to that main domain 🤷‍♂️ 