### PR TITLE
Add a Scale Control to the map

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,6 +58,7 @@
         :opacity="layer.opacity"
       />
 
+      <mapbox-scale-control />
       <map-zoom :extent="zoomExtent" />
       <MapMouseMove @mousemove="onMouseMove" />
       <v-mapbox-navigation-control />
@@ -94,6 +95,7 @@
   import getFeatureInfo from '~/lib/get-feature-info'
   import MapMouseMove from './components/MapComponents/MapMouseMove.js'
   import MapboxCoordinates from './components/MapboxCoordinates/MapboxCoordinates.vue'
+  import MapboxScaleControl from './components/MapboxScaleControl/MapboxScaleControl.vue'
   import debounce from '~/lib/debounce'
   import axios from 'axios'
   import LayersDialog from '~/components/LayersDialog/LayersDialog'
@@ -122,6 +124,7 @@
       MapboxCoordinates,
       LayersDialog,
       SearchBar,
+      MapboxScaleControl,
     },
 
     data: () => ({
@@ -272,17 +275,20 @@
     },
   }
 </script>
-<style>
 
+<style>
 .mapboxgl-ctrl-top-right {
-    top: 0;
-    right: 0;
+  top: 0;
+  right: 0;
 }
 
 @media only screen and (max-width:1199px) {
   .mapboxgl-ctrl-top-right {
     top: 0;
-    right: calc(100vw - 560px);
+    right: calc(100vw - 600px);
   }
+  .mapboxgl-ctrl-top-right .mapboxgl-ctrl {
+    float: left;
   }
+}
 </style>

--- a/src/components/MapboxScaleControl/MapboxScaleControl.vue
+++ b/src/components/MapboxScaleControl/MapboxScaleControl.vue
@@ -1,0 +1,20 @@
+<script>
+  import Mapbox from 'mapbox-gl'
+
+  export default {
+    methods: {
+      deferredMountedTo(map) {
+        window.map = map
+
+        const mbScale = new Mapbox.ScaleControl({
+          maxWidth: 100,
+          unit: 'metric',
+        })
+
+        map.addControl(mbScale, 'top-right')
+      },
+    },
+
+    render: () => null,
+  }
+</script>


### PR DESCRIPTION
Ticket: https://issuetracker.deltares.nl/browse/RWSVIEWERS-367

The [scale control](https://docs.mapbox.com/mapbox-gl-js/example/navigation-scale/) changes size to display the scale of the visible section of the map.

![image](https://github.com/openearth/rws-viewer/assets/15196342/77d3924e-ee50-4356-b599-bbc7f0e33f3e)
