### PR TITLE
Fix to update filters when all are removed

### DIFF
--- a/src/components/KeyValueFilter/KeyValueFilter.vue
+++ b/src/components/KeyValueFilter/KeyValueFilter.vue
@@ -134,9 +134,9 @@
         this.enabledFilters = []
       },
       enabledFilters: {
-        handler(value) {
-          if (value.length) {
-            this.$emit('change', value)
+        handler(newValue, oldValue) {
+          if (newValue.length || newValue.length !== oldValue.length) {
+            this.$emit('change', newValue)
           }
         },
         deep: true,


### PR DESCRIPTION
Ticket: https://issuetracker.deltares.nl/browse/RWSVIEWERS-307

To reproduce:
- Go to http://localhost:8888/ihm-viewer/download/api?layers=141123586,85222873
- Download data from the Natura2000 layer filtered by year = 2019
- Remove the filter
- Before: the filter was still enabled -> Now: the filter is removed (the request is really slow)

The bug only occurred when you removed the last filter applied, since `value.length` was 0/falsy.
