### PR TITLE
Set a different radius for the bbox depending on service type

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -213,6 +213,7 @@
         const feature = await getFeatureInfo({
           url: this.selectedLayerForSelection.url,
           layer: this.selectedLayerForSelection.layer,
+          serviceType: this.selectedLayerForSelection.serviceType,
           ...clickData,
         })
     

--- a/src/components/MapComponents/MapLayerInfo.vue
+++ b/src/components/MapComponents/MapLayerInfo.vue
@@ -48,6 +48,7 @@
         const info = await getFeatureInfo({
           layer: infoLayer,
           url: this.layer.url,
+          serviceType: this.layer.serviceType,
           lng, lat,
         })
         

--- a/src/lib/get-feature-info.js
+++ b/src/lib/get-feature-info.js
@@ -18,7 +18,7 @@ function extractFeatureId(feature) {
   
   
 }
-export default async function getFeatureInfo({ url, lng, lat,  layer, x=50, y=50, bounds, width=110, height=110 }) {
+export default async function getFeatureInfo({ url, lng, lat,  layer, serviceType, x=50, y=50, bounds, width=110, height=110 }) {
   let bbox = null
   // Bounding box used with area selection.
  
@@ -33,11 +33,13 @@ export default async function getFeatureInfo({ url, lng, lat,  layer, x=50, y=50
 
   // Bounding box used with single point selection.
   if (lng && lat) {
+    // WCS requires a smaller bounding box to prevent selecting nearby points.
+    const radius = serviceType === 'wfs' ? 0.01 : 0.00001
     bbox = [
-      (lng - 0.001),
-      (lat - 0.001),
-      (lng + 0.001),
-      (lat + 0.001),
+      (lng - radius),
+      (lat - radius),
+      (lng + radius),
+      (lat + radius),
     ].join(',')
   }
   


### PR DESCRIPTION
Ticket: https://issuetracker.deltares.nl/browse/RWSVIEWERS-298

WCS layer example: https://viewer.openearth.nl/water-info-extra-viewer/?folders=85223135,85223139,85223152&layers=85223089&layerNames=LIDAR%202011-05

WFS layer example: https://viewer.openearth.nl/water-info-extra-viewer/?folders=85223135,85223139,85223147&layers=85223097&layerNames=Waarnemingen%20%28A2M%29

WFS are vector layers, and they are displayed as small more sparse points. Because of that the cursor click is rarely accurate enough to hit the actual point, and no data is returned. By making the bbox bigger there are more chances of hitting the point the user intended to click. Still it is possible we won't hit anything.
While WCS are raster layers, and they are displayed as areas. A smaller bounding box prevents the user from getting information from a nearby point instead of the point they actually wanted to see.

This won't fully fix the bug, but does get better results and it is the best we can do without having to customize the bbox per layer or having to display vector layers as actual selectable vectors.