### PR TITLE
Clear predefined filters when changing a layer in the time travel view

### DIFF
--- a/src/store/modules/data/index.js
+++ b/src/store/modules/data/index.js
@@ -57,6 +57,9 @@ export default {
     SET_CQL_FILTER(state, filter) {
       state.cqlFilter = filter
     },
+    RESET_CQL_FILTER(state) {
+      state.cqlFilter = null
+    },
     RESET_TIME_EXTENT(state) {
       state.timeExtent = []
     },
@@ -172,6 +175,9 @@ export default {
     },
     setCQLFilter({ commit }, filter) {
       commit('SET_CQL_FILTER', filter)
+    },
+    resetCQLFilter({commit}) {
+      commit('RESET_CQL_FILTER')
     }, 
     setOpenedFolders({ commit }, folders) {
       commit('SET_OPENED_FOLDERS', folders)

--- a/src/views/Filters.vue
+++ b/src/views/Filters.vue
@@ -110,6 +110,7 @@
       selectedLayer() {
         if (this.selectedLayer) {
           this.setTimeExtent(this.selectedLayer.timeExtent)
+          this.resetCQLFilter()
         }
       },
       selectedLayerCode( ) {
@@ -124,7 +125,7 @@
       },
     },
     methods: {
-      ...mapActions('data', [ 'setTimeExtent', 'setCQLFilter' ] ),
+      ...mapActions('data', [ 'setTimeExtent', 'setCQLFilter', 'resetCQLFilter' ] ),
       ...mapActions('map', [ 'setFilteredLayerId', 'reloadLayerOnMap' ]),
       setFilter(value) {
         const filter = `${ this.filterName }='${ value }'`


### PR DESCRIPTION
I added a function in the data store that resets the filters to null.
In Filters.vue I called this function whenever the selected layer changes.