### PR TITLE
Feat/vector tiles clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,31 @@ This application is an OGC-based map viewer and downloader that integrates WMS, 
 | --- | --- | --- |
 | Select a layer on the map | `WMS/WMTS GetCapabilities` | Layer metadata (bbox, version, dimensions, formats) |
 | View selected layer | `WMS GetMap` or `WMTS GetTile` | Renderable map tiles |
+| Click map with active layer(s)* | `WMS GetFeatureInfo` (raster) or rendered vector features (MVT) | Combined attribute popup per layer with data |
 | Open Download and choose layer | `WFS/WCS GetCapabilities` | Supported output formats |
 | Configure filters (WFS only) | `WFS DescribeFeatureType` | Filterable attributes |
 | Start download (WFS) | `WFS GetFeature` | Vector dataset payload |
 | Start download (WCS) | `WCS GetCoverage` | Raster coverage payload |
+
+\* **Map click uses two paths depending on layer type.** Raster layers (WMS / WMTS without vector tiles) trigger one parallel `WMS GetFeatureInfo` request per active layer to GeoServer. Vector tile layers (WMTS MVT) skip `GetFeatureInfo` entirely — Mapbox GL `map.queryRenderedFeatures` reads feature properties from tiles already rendered at the click point. Both paths feed into a single combined popup. See [Map click info popup](#map-click-info-popup) below.
+
+### Map click info popup
+
+Clicking the map with one or more active layers opens a single combined attribute popup at the click location. The popup shows one titled section per layer that returned data, ordered top-to-bottom by map stacking order.
+
+#### Behaviour by layer type
+
+| Layer type | Detection | Data source |
+| --- | --- | --- |
+| Vector tiles (WMTS MVT) | Layer has `featureType` from capabilities | `map.queryRenderedFeatures` at the click point |
+| Raster / WMS / WMTS | No `featureType` | Per-layer `WMS GetFeatureInfo` (parallel requests) |
+
+- Only one popup is shown at a time; a new click replaces the previous popup.
+- While raster `GetFeatureInfo` requests are in flight, a loading placeholder popup is shown.
+- Raster responses that return `GRAY_INDEX` are renamed to `<layerName>_value` per layer.
+- Layers with no data at the click point (empty `GetFeatureInfo` response or no rendered vector feature) are omitted from the popup.
+
+ a separate code path used for feature selection in draw mode, not the map info popup.
 
 ### Simplified schema
 
@@ -149,6 +170,12 @@ flowchart TD
   A[User selects map layer] --> B[WMS/WMTS GetCapabilities]
   B --> C[User views layer on map]
   C --> D[WMS GetMap or WMTS GetTile]
+  D --> K[User clicks map]
+  K --> L{Layer type}
+  L -->|Vector MVT| M[queryRenderedFeatures]
+  L -->|Raster WMS| N[GetFeatureInfo per layer]
+  M --> O[Combined info popup]
+  N --> O
   D --> E[User opens Download and selects layer]
   E --> F[WFS/WCS GetCapabilities]
   F --> G{Data service type}

--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,6 @@
         :options="layer"
         :opacity="layer.opacity"
         :hoverable="layer.source && layer.source.type === 'vector'"
-        :highlightable="layer.source && layer.source.type === 'vector'"
       />
 
       <mapbox-scale-control />

--- a/src/App.vue
+++ b/src/App.vue
@@ -94,6 +94,8 @@
         :before="wmsLayerIds[index - 1]"
         :options="layer"
         :opacity="layer.opacity"
+        :hoverable="layer.source && layer.source.type === 'vector'"
+        :highlightable="layer.source && layer.source.type === 'vector'"
       />
 
       <mapbox-scale-control />

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,7 +113,6 @@
       />
       <map-layer-info
         v-if="activeFlattenedLayers.length && !drawMode"
-        :layer="activeFlattenedLayers[0]"
       />
     </v-mapbox>
   </app-shell>

--- a/src/components/MapComponents/MapLayer.js
+++ b/src/components/MapComponents/MapLayer.js
@@ -70,9 +70,6 @@ export default {
       }
 
       const layerId = this.options.id
-      if (this.clickable) {
-        map.on('click', layerId, this.clickFn)
-      }
       if (this.highlightable) {
         map.on('click', layerId, this.highlightClickFn)
         map.on('click', this.clearHighlightOnOutsideClick)
@@ -91,15 +88,14 @@ export default {
       const map = this.getMap()
       if (map) {
         const layerId = this.options.id
-        if (this.clickable) {
-          map.off('click', layerId, this.clickFn)
-        }
         if (this.highlightable) {
+          console.log('highlightable', this.highlightable)
           map.off('click', layerId, this.highlightClickFn)
           map.off('click', this.clearHighlightOnOutsideClick)
           this.clearSelectedFeature()
         }
         if (this.hoverable) {
+          console.log('hoverable', this.hoverable)
           map.off('mouseenter', layerId, this.mouseEnterFn)
           map.off('mouseleave', layerId, this.mouseLeaveFn)
         }
@@ -176,10 +172,6 @@ export default {
       if (!features || !features.length) {
         this.clearSelectedFeature()
       }
-    },
-
-    clickFn(e) {
-      this.$emit('click', e)
     },
 
     mouseEnterFn() {

--- a/src/components/MapComponents/MapLayer.js
+++ b/src/components/MapComponents/MapLayer.js
@@ -23,6 +23,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    hoverable: {
+      type: Boolean,
+      default: false,
+    },
+    highlightable: {
+      type: Boolean,
+      default: false,
+    },
 
     opacity: {
       type: Number,
@@ -33,6 +41,7 @@ export default {
 
   data: () => ({
     isInitialized: false,
+    selectedFeatureState: null,
   }),
 
   methods: {
@@ -60,9 +69,15 @@ export default {
         map.addLayer(this.options)
       }
 
+      const layerId = this.options.id
       if (this.clickable) {
-        const layerId = this.options.id
         map.on('click', layerId, this.clickFn)
+      }
+      if (this.highlightable) {
+        map.on('click', layerId, this.highlightClickFn)
+        map.on('click', this.clearHighlightOnOutsideClick)
+      }
+      if (this.hoverable) {
         map.on('mouseenter', layerId, this.mouseEnterFn)
         map.on('mouseleave', layerId, this.mouseLeaveFn)
       }
@@ -76,6 +91,19 @@ export default {
       const map = this.getMap()
       if (map) {
         const layerId = this.options.id
+        if (this.clickable) {
+          map.off('click', layerId, this.clickFn)
+        }
+        if (this.highlightable) {
+          map.off('click', layerId, this.highlightClickFn)
+          map.off('click', this.clearHighlightOnOutsideClick)
+          this.clearSelectedFeature()
+        }
+        if (this.hoverable) {
+          map.off('mouseenter', layerId, this.mouseEnterFn)
+          map.off('mouseleave', layerId, this.mouseLeaveFn)
+        }
+
         const layer = map.getLayer(layerId)
         if (layer) {
           const layerSource = layer.source
@@ -83,12 +111,70 @@ export default {
           if (layerSource && !map.getStyle().layers.some(({ source }) => source === layerSource)) {
             map.removeSource(layerSource)
           }
-          if (this.clickable) {
-            map.off('click', layerId, this.clickFn)
-            map.off('mouseenter', layerId, this.mouseEnterFn)
-            map.off('mouseleave', layerId, this.mouseLeaveFn)
-          }
         }
+      }
+    },
+
+    setFeatureState(state, selected) {
+      const map = this.getMap()
+      if (!map || !state) {
+        return
+      }
+      const { source, sourceLayer, id } = state
+      if (source == null || sourceLayer == null || id == null) {
+        return
+      }
+      map.setFeatureState({ source, sourceLayer, id }, { selected })
+    },
+
+    clearSelectedFeature() {
+      if (!this.selectedFeatureState) {
+        return
+      }
+      this.setFeatureState(this.selectedFeatureState, false)
+      this.selectedFeatureState = null
+    },
+
+    highlightClickFn(e) {
+      const feature = e.features && e.features[0]
+      if (!feature || feature.id == null) {
+        return
+      }
+      const next = {
+        source: feature.source,
+        sourceLayer: feature.sourceLayer || this.options['source-layer'],
+        id: feature.id,
+      }
+      if (next.source == null || next.sourceLayer == null) {
+        return
+      }
+
+      const current = this.selectedFeatureState
+      const isSameFeature = current &&
+        current.source === next.source &&
+        current.sourceLayer === next.sourceLayer &&
+        current.id === next.id
+
+      this.clearSelectedFeature()
+      if (!isSameFeature) {
+        this.setFeatureState(next, true)
+        this.selectedFeatureState = next
+      }
+    },
+
+    clearHighlightOnOutsideClick(e) {
+      if (!this.selectedFeatureState) {
+        return
+      }
+      const map = this.getMap()
+      if (!map || !this.options || !this.options.id) {
+        return
+      }
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: [ this.options.id ],
+      })
+      if (!features || !features.length) {
+        this.clearSelectedFeature()
       }
     },
 

--- a/src/components/MapComponents/MapLayerInfo.vue
+++ b/src/components/MapComponents/MapLayerInfo.vue
@@ -60,7 +60,7 @@
           properties = { ...(feature.properties || {}) }
         } else {
       
-          const loadingPopup = new Mapbox.Popup().setLngLat(event.lngLat).addTo(map)
+          const featureInfoPending = new Mapbox.Popup().setLngLat(event.lngLat).addTo(map)
           let infoLayer
           if (this.layer.downloadLayer) {
             infoLayer = this.layer.downloadLayer
@@ -73,7 +73,7 @@
             serviceType: this.layer.dataServiceType,
             lng, lat,
           })
-          loadingPopup.remove()
+          featureInfoPending.remove()
           if (!info) {
             return
           }

--- a/src/components/MapComponents/MapLayerInfo.vue
+++ b/src/components/MapComponents/MapLayerInfo.vue
@@ -29,6 +29,16 @@
         // Needed for vue2mapbox-gl to work
         // https://github.com/openearth/vue2mapbox-gl/blob/master/src/components/VMapbox.vue#L176
       },
+      isVectorInfoLayer() {
+        return Boolean(this.layer && this.layer.featureType)
+      },
+      getVectorLayerId() {
+        const layerName = this.layer && this.layer.layer
+        if (!layerName || !layerName.includes(':')) {
+          return null
+        }
+        return layerName.split(':')[1]
+      },
       removeActivePopup() {
         if (this.activePopup) {
           this.activePopup.remove()
@@ -38,65 +48,87 @@
       async cb(event) {
         const map = this.getMap()
         const { lng, lat } = event.lngLat
-        
         this.removeActivePopup()
 
-        const loadingPopup = new Mapbox.Popup().setLngLat(event.lngLat).addTo(map)
-        let infoLayer
-        if (this.layer.downloadLayer) {
-          infoLayer = this.layer.downloadLayer
-       
-        } else {
-          infoLayer = this.layer.layer
-        }
-        
-        const info = await getFeatureInfo({
-          layer: infoLayer,
-          url: this.layer.url,
-          serviceType: this.layer.dataServiceType,
-          lng, lat,
-        })
-        
-        loadingPopup.remove()
-
-        if (info) {
-          const { properties } = info
-
-          if ('GRAY_INDEX' in properties) {
-            properties[`${ this.layer.name }_value`] = properties['GRAY_INDEX']
-            delete properties['GRAY_INDEX']
+        let properties = null
+        if (this.isVectorInfoLayer()) {
+          console.log('event', event)
+          const feature = event.features && event.features[0]
+          if (!feature) {
+            return
           }
-          
-          // Get primary color from Vuetify theme
-          const primaryColor = this.$vuetify.theme.currentTheme.primary
-          
-          const popup = new Mapbox.Popup()
-            .setLngLat(event.lngLat)
-            .setHTML(json2HtmlTable(this.layer.name, [ properties ]))
-            .addTo(map)
-          
-          // Apply primary color to popup header after it's added to the map
-          setTimeout(() => {
-            const popupElement = popup.getElement()
-            const header = popupElement.querySelector('.mapboxgl-popup-content p')
-            if (header) {
-              header.style.backgroundColor = primaryColor
-              header.style.color = 'white'
-              header.style.padding = '2px'
-              header.style.margin = '0'
-            }
-          }, 0)
-          
-          this.$emit('set-active-popup', popup)
+          properties = { ...(feature.properties || {}) }
+        } else {
+      
+          const loadingPopup = new Mapbox.Popup().setLngLat(event.lngLat).addTo(map)
+          let infoLayer
+          if (this.layer.downloadLayer) {
+            infoLayer = this.layer.downloadLayer
+          } else {
+            infoLayer = this.layer.layer
+          }
+          const info = await getFeatureInfo({
+            layer: infoLayer,
+            url: this.layer.url,
+            serviceType: this.layer.dataServiceType,
+            lng, lat,
+          })
+          loadingPopup.remove()
+          if (!info) {
+            return
+          }
+          properties = { ...(info.properties || {}) }
         }
+
+        if ('GRAY_INDEX' in properties) {
+          properties[`${ this.layer.name }_value`] = properties['GRAY_INDEX']
+          delete properties['GRAY_INDEX']
+        }
+
+        // Get primary color from Vuetify theme
+        const primaryColor = this.$vuetify.theme.currentTheme.primary
+        
+        const popup = new Mapbox.Popup()
+          .setLngLat(event.lngLat)
+          .setHTML(json2HtmlTable(this.layer.name, [ properties ]))
+          .addTo(map)
+        
+        // Apply primary color to popup header after it's added to the map
+        setTimeout(() => {
+          const popupElement = popup.getElement()
+          const header = popupElement.querySelector('.mapboxgl-popup-content p')
+          if (header) {
+            header.style.backgroundColor = primaryColor
+            header.style.color = 'white'
+            header.style.padding = '2px'
+            header.style.margin = '0'
+          }
+        }, 0)
+        
+        this.$emit('set-active-popup', popup)
+      },
+      getClickListenerArgs() {
+        if (this.isVectorInfoLayer()) {
+          const layerId = this.getVectorLayerId()
+          if (layerId) {
+            return [ 'click', layerId, this.cb ]
+          }
+        }
+        return [ 'click', this.cb ]
       },
       addListener() {
         const map = this.getMap()
-        map.on('click', this.cb)
+        map.on(...this.getClickListenerArgs())
       },
       removeListener() {
         const map = this.getMap()
-        map.off('click', this.cb)
+        map.off(...this.getClickListenerArgs())
+      },
+    },
+    watch: {
+      layer() {
+        this.removeListener()
+        this.addListener()
       },
     },
     render: () => null,

--- a/src/components/MapComponents/MapLayerInfo.vue
+++ b/src/components/MapComponents/MapLayerInfo.vue
@@ -1,21 +1,19 @@
 <script>
+  import { mapGetters } from 'vuex'
   import Mapbox from 'mapbox-gl'
-  import getFeatureInfo from '~/lib/get-feature-info' 
-  import json2HtmlTable from '~/lib/json-2-html-table'
+  import getFeatureInfo from '~/lib/get-feature-info'
+  import { buildCombinedPopup } from '~/lib/json-2-html-table'
 
   export default {
     name: 'MapLayerInfo',
     inject: [ 'getMap' ],
-    props: {
-      layer: {
-        type: Object,
-        required: true,
-      },
-      activePopup: {
-        type: Object,
-        required: false,
-        default: null,
-      },
+    data() {
+      return {
+        activePopup: null,
+      }
+    },
+    computed: {
+      ...mapGetters('map', [ 'activeFlattenedLayers' ]),
     },
     created() {
       this.addListener()
@@ -29,11 +27,11 @@
         // Needed for vue2mapbox-gl to work
         // https://github.com/openearth/vue2mapbox-gl/blob/master/src/components/VMapbox.vue#L176
       },
-      isVectorInfoLayer() {
-        return Boolean(this.layer && this.layer.featureType)
+      isVectorInfoLayer(layer) {
+        return Boolean(layer && layer.featureType)
       },
-      getVectorLayerId() {
-        const layerName = this.layer && this.layer.layer
+      getVectorLayerId(layer) {
+        const layerName = layer && layer.layer
         if (!layerName || !layerName.includes(':')) {
           return null
         }
@@ -42,93 +40,143 @@
       removeActivePopup() {
         if (this.activePopup) {
           this.activePopup.remove()
-          this.$emit('remove-active-popup', null)
+          this.activePopup = null
         }
       },
-      async cb(event) {
-        const map = this.getMap()
+      normalizeProperties(layer, properties) {
+        const normalized = { ...properties }
+
+        if ('GRAY_INDEX' in normalized) {
+          normalized[`${ layer.name }_value`] = normalized['GRAY_INDEX']
+          delete normalized['GRAY_INDEX']
+        }
+
+        return normalized
+      },
+      getLayerIndex(layer) {
+        return this.activeFlattenedLayers.findIndex(activeLayer => activeLayer.id === layer.id)
+      },
+      getVectorResults(map, event, vectorLayers) {
+        const vectorLayerIds = vectorLayers
+          .map(layer => this.getVectorLayerId(layer))
+          .filter(Boolean)
+
+        if (!vectorLayerIds.length) {
+          return []
+        }
+
+        const features = map.queryRenderedFeatures(event.point, {
+          layers: vectorLayerIds,
+        })
+
+        return vectorLayers.reduce((results, layer) => {
+          const layerId = this.getVectorLayerId(layer)
+          const feature = features.find(({ layer: featureLayer }) => featureLayer.id === layerId)
+
+          if (!feature || !feature.properties) {
+            return results
+          }
+
+          return [
+            ...results,
+            {
+              layer,
+              properties: this.normalizeProperties(layer, feature.properties),
+            },
+          ]
+        }, [])
+      },
+      async getRasterResults(map, event, rasterLayers) {
+        if (!rasterLayers.length) {
+          return []
+        }
+
         const { lng, lat } = event.lngLat
-        this.removeActivePopup()
-
-        let properties = null
-        if (this.isVectorInfoLayer()) {
-          console.log('event', event)
-          const feature = event.features && event.features[0]
-          if (!feature) {
-            return
-          }
-          properties = { ...(feature.properties || {}) }
-        } else {
-      
-          const featureInfoPending = new Mapbox.Popup().setLngLat(event.lngLat).addTo(map)
-          let infoLayer
-          if (this.layer.downloadLayer) {
-            infoLayer = this.layer.downloadLayer
-          } else {
-            infoLayer = this.layer.layer
-          }
-          const info = await getFeatureInfo({
-            layer: infoLayer,
-            url: this.layer.url,
-            serviceType: this.layer.dataServiceType,
-            lng, lat,
-          })
-          featureInfoPending.remove()
-          if (!info) {
-            return
-          }
-          properties = { ...(info.properties || {}) }
-        }
-
-        if ('GRAY_INDEX' in properties) {
-          properties[`${ this.layer.name }_value`] = properties['GRAY_INDEX']
-          delete properties['GRAY_INDEX']
-        }
-
-        // Get primary color from Vuetify theme
-        const primaryColor = this.$vuetify.theme.currentTheme.primary
-        
-        const popup = new Mapbox.Popup()
+        const featureInfoPending = new Mapbox.Popup()
           .setLngLat(event.lngLat)
-          .setHTML(json2HtmlTable(this.layer.name, [ properties ]))
           .addTo(map)
-        
-        // Apply primary color to popup header after it's added to the map
+
+        try {
+          const responses = await Promise.all(
+            rasterLayers.map(async (layer) => {
+              const infoLayer = layer.downloadLayer || layer.layer
+              const info = await getFeatureInfo({
+                layer: infoLayer,
+                url: layer.url,
+                serviceType: layer.dataServiceType,
+                lng,
+                lat,
+              })
+
+              if (!info || !info.properties) {
+                return null
+              }
+
+              return {
+                layer,
+                properties: this.normalizeProperties(layer, info.properties),
+              }
+            }),
+          )
+
+          return responses.filter(Boolean)
+        } finally {
+          featureInfoPending.remove()
+        }
+      },
+      sortResultsByStackingOrder(results) {
+        return [ ...results ].sort((a, b) => this.getLayerIndex(a.layer) - this.getLayerIndex(b.layer))
+      },
+      stylePopupHeaders(popup) {
+        const primaryColor = this.$vuetify.theme.currentTheme.primary
+
         setTimeout(() => {
           const popupElement = popup.getElement()
-          const header = popupElement.querySelector('.mapboxgl-popup-content p')
-          if (header) {
+          const headers = popupElement.querySelectorAll('.mapboxgl-popup-content p')
+
+          headers.forEach((header) => {
             header.style.backgroundColor = primaryColor
             header.style.color = 'white'
             header.style.padding = '2px'
             header.style.margin = '0'
-          }
+          })
         }, 0)
-        
-        this.$emit('set-active-popup', popup)
       },
-      getClickListenerArgs() {
-        if (this.isVectorInfoLayer()) {
-          const layerId = this.getVectorLayerId()
-          if (layerId) {
-            return [ 'click', layerId, this.cb ]
-          }
+      async handleClick(event) {
+        const map = this.getMap()
+        this.removeActivePopup()
+
+        const vectorLayers = this.activeFlattenedLayers.filter(layer => this.isVectorInfoLayer(layer))
+        const rasterLayers = this.activeFlattenedLayers.filter(layer => !this.isVectorInfoLayer(layer))
+
+        const vectorResults = this.getVectorResults(map, event, vectorLayers)
+        const rasterResults = await this.getRasterResults(map, event, rasterLayers)
+        const results = this.sortResultsByStackingOrder([ ...vectorResults, ...rasterResults ])
+
+        if (!results.length) {
+          return
         }
-        return [ 'click', this.cb ]
+
+        const popup = new Mapbox.Popup()
+          .setLngLat(event.lngLat)
+          .setHTML(buildCombinedPopup(
+            results.map(({ layer, properties }) => ({
+              title: layer.name,
+              properties,
+            })),
+          ))
+          .addTo(map)
+
+        this.stylePopupHeaders(popup)
+        this.activePopup = popup
       },
       addListener() {
         const map = this.getMap()
-        map.on(...this.getClickListenerArgs())
+        map.on('click', this.handleClick)
       },
       removeListener() {
         const map = this.getMap()
-        map.off(...this.getClickListenerArgs())
-      },
-    },
-    watch: {
-      layer() {
-        this.removeListener()
-        this.addListener()
+        map.off('click', this.handleClick)
       },
     },
     render: () => null,

--- a/src/lib/build-wmts-vector-layer.js
+++ b/src/lib/build-wmts-vector-layer.js
@@ -3,10 +3,47 @@ import buildGeoserverUrl from './build-geoserver-url'
 const defaultUrl = process.env.VUE_APP_GEOSERVER_BASE_URL
 const VECTOR_TILE_FORMAT = 'application/vnd.mapbox-vector-tile'
 
+function mapboxLayerTypeFromGeometry(geometryType) {
+  switch (geometryType) {
+    case 'Polygon':
+    case 'MultiPolygon':
+      return 'fill'
+    case 'LineString':
+    case 'MultiLineString':
+      return 'line'
+    case 'Point':
+    case 'MultiPoint':
+      return 'circle'
+    default:
+      return 'fill'
+  }
+}
+
+const selectedCase = (selectedValue, defaultValue) => [
+  'case',
+  [ 'boolean', [ 'feature-state', 'selected' ], false ],
+  selectedValue,
+  defaultValue,
+]
+
+const defaultPaintByType = {
+  fill: {
+    'fill-color': selectedCase('#ffcc00', 'black'),
+    'fill-opacity': selectedCase(1, 0.8),
+  },
+  line: {
+    'line-color': selectedCase('#ffcc00', 'black'),
+    'line-width': selectedCase(3, 1),
+  },
+  circle: {
+    'circle-color': selectedCase('#ffcc00', 'black'),
+    'circle-radius': selectedCase(8, 5),
+  },
+}
+
 /**
  * Build a Mapbox GL layer spec for WMTS vector tiles (MVT).
- * Same inputs as the raster WMTS builder, plus vectorType (e.g. 'line', 'fill', 'circle')
- * from the feature geometry type.
+ * Layer type (fill / line / circle) is derived from featureType (GeoJSON geometry type).
  */
 export default function buildWmtsVectorLayer ({
   url: rawUrl = defaultUrl,
@@ -16,7 +53,7 @@ export default function buildWmtsVectorLayer ({
   paint = {},
   mapServiceVersion = '1.0.0',
   bbox = [],
-  vectorType,
+  featureType,
 }) {
   const url = new URL(rawUrl)
   const tile = buildGeoserverUrl({
@@ -36,25 +73,12 @@ export default function buildWmtsVectorLayer ({
   })
 
   const sourceLayerId = layer.split(':')[1]
-  const defaultFillPaint = {
-    'fill-color': [
-      'case',
-      [ 'boolean', [ 'feature-state', 'selected' ], false ],
-      '#ffcc00',
-      'black',
-    ],
-    'fill-opacity': [
-      'case',
-      [ 'boolean', [ 'feature-state', 'selected' ], false ],
-      1,
-      0.8,
-    ],
-  }
+  const layerType = mapboxLayerTypeFromGeometry(featureType)
 
   return {
     id: sourceLayerId,
     layer,
-    type: "fill",
+    type: layerType,
     source: {
       type: 'vector',
       tiles: [ tile ],
@@ -62,7 +86,7 @@ export default function buildWmtsVectorLayer ({
     },
     'source-layer': sourceLayerId,
     paint: {
-      ...defaultFillPaint,
+      ...defaultPaintByType[layerType],
       ...paint,
     },
   }

--- a/src/lib/build-wmts-vector-layer.js
+++ b/src/lib/build-wmts-vector-layer.js
@@ -19,25 +19,18 @@ function mapboxLayerTypeFromGeometry(geometryType) {
   }
 }
 
-const selectedCase = (selectedValue, defaultValue) => [
-  'case',
-  [ 'boolean', [ 'feature-state', 'selected' ], false ],
-  selectedValue,
-  defaultValue,
-]
-
 const defaultPaintByType = {
   fill: {
-    'fill-color': selectedCase('#ffcc00', 'black'),
-    'fill-opacity': selectedCase(1, 0.8),
+    'fill-color': 'black',
+    'fill-opacity': 0,
   },
   line: {
-    'line-color': selectedCase('#ffcc00', 'black'),
-    'line-width': selectedCase(3, 1),
+    'line-color': 'black',
+    'line-width': 0,
   },
   circle: {
-    'circle-color': selectedCase('#ffcc00', 'black'),
-    'circle-radius': selectedCase(8, 5),
+    'circle-color': 'black',
+    'circle-radius': 0,
   },
 }
 
@@ -47,7 +40,6 @@ const defaultPaintByType = {
  */
 export default function buildWmtsVectorLayer ({
   url: rawUrl = defaultUrl,
-  id,
   layer,
   style = '',
   paint = {},

--- a/src/lib/build-wmts-vector-layer.js
+++ b/src/lib/build-wmts-vector-layer.js
@@ -1,0 +1,55 @@
+import buildGeoserverUrl from './build-geoserver-url'
+
+const defaultUrl = process.env.VUE_APP_GEOSERVER_BASE_URL
+const VECTOR_TILE_FORMAT = 'application/vnd.mapbox-vector-tile'
+
+/**
+ * Build a Mapbox GL layer spec for WMTS vector tiles (MVT).
+ * Same inputs as the raster WMTS builder, plus vectorType (e.g. 'line', 'fill', 'circle')
+ * from the feature geometry type.
+ */
+export default function buildWmtsVectorLayer ({
+  url: rawUrl = defaultUrl,
+  id,
+  layer,
+  style = '',
+  paint = {},
+  mapServiceVersion = '1.0.0',
+  bbox = [],
+  vectorType,
+}) {
+  const url = new URL(rawUrl)
+  const tile = buildGeoserverUrl({
+    url: url.origin + url.pathname,
+    service: 'WMTS',
+    request: 'GetTile',
+    layer,
+    style,
+    version: mapServiceVersion,
+    format: VECTOR_TILE_FORMAT,
+    tilematrixset: 'EPSG:900913',
+    tilematrix: 'EPSG:900913:{z}',
+    tilerow: '{y}',
+    tilecol: '{x}',
+    encode: false,
+    transparent: true,
+  })
+
+  const sourceLayerId = layer.split(':')[1]
+
+  return {
+    id: sourceLayerId,
+    layer,
+    type: "fill",
+    source: {
+      type: 'vector',
+      tiles: [ tile ],
+      ...(bbox && Array.isArray(bbox) && bbox.length > 0 && { bounds: bbox }),
+    },
+    'source-layer': sourceLayerId,
+      "paint": {
+        "fill-color": "black",
+        "fill-opacity": 1
+    },
+  }
+}

--- a/src/lib/build-wmts-vector-layer.js
+++ b/src/lib/build-wmts-vector-layer.js
@@ -36,6 +36,20 @@ export default function buildWmtsVectorLayer ({
   })
 
   const sourceLayerId = layer.split(':')[1]
+  const defaultFillPaint = {
+    'fill-color': [
+      'case',
+      [ 'boolean', [ 'feature-state', 'selected' ], false ],
+      '#ffcc00',
+      'black',
+    ],
+    'fill-opacity': [
+      'case',
+      [ 'boolean', [ 'feature-state', 'selected' ], false ],
+      1,
+      0.8,
+    ],
+  }
 
   return {
     id: sourceLayerId,
@@ -47,9 +61,9 @@ export default function buildWmtsVectorLayer ({
       ...(bbox && Array.isArray(bbox) && bbox.length > 0 && { bounds: bbox }),
     },
     'source-layer': sourceLayerId,
-      "paint": {
-        "fill-color": "black",
-        "fill-opacity": 1
+    paint: {
+      ...defaultFillPaint,
+      ...paint,
     },
   }
 }

--- a/src/lib/build-wmts-vector-layer.js
+++ b/src/lib/build-wmts-vector-layer.js
@@ -27,10 +27,12 @@ const defaultPaintByType = {
   line: {
     'line-color': 'black',
     'line-width': 0,
+    'line-opacity': 0,
   },
   circle: {
     'circle-color': 'black',
-    'circle-radius': 0,
+    'circle-radius': 10,
+    'circle-opacity': 0,
   },
 }
 

--- a/src/lib/get-capabilities.js
+++ b/src/lib/get-capabilities.js
@@ -7,6 +7,7 @@ import {
   WCS_LAYER_TYPE,
   WFS_LAYER_TYPE,
 } from '~/lib/constants'
+import getFeature from '~/lib/get-feature'
 
 
 
@@ -306,7 +307,7 @@ async function readWmtsCapabilitiesProperties(capabilities, layerObject) {
     map(getTagContent),
     uniq,
   )()
-
+console.log('acceptedFormats', acceptedFormats)
  const bbox = pipe(
   () => [ ...capabilities.querySelectorAll('Layer') ],
   filter(el => {
@@ -329,7 +330,26 @@ async function readWmtsCapabilitiesProperties(capabilities, layerObject) {
   // for the wcs/wfs reqeusts we need to change the url to the wms url of the service
   const wmsServiceUrl = layerObject.url.replace('/gwc/service/wmts', `/${ workspace }/wms`)
   const dataServiceType = await getDataServiceType(wmsServiceUrl, layerName)
-  return { dataServiceType, acceptedFormats, mapServiceVersion, bbox, wmsServiceUrl }
+
+  let getFeatureResponse
+  const isVectorTiles = acceptedFormats.some(
+    f => f && f.trim() === 'application/vnd.mapbox-vector-tile'
+  )
+  if (isVectorTiles) {
+    const wfsServiceUrl = wmsServiceUrl.replace(/(wms|wcs)/i, 'wfs')
+    getFeatureResponse = await getFeature({
+      url: wfsServiceUrl,
+      layer: layerObject.layer,
+      count: 1,
+    })
+  }
+  let featureType;
+  if (getFeatureResponse !== undefined) {
+    featureType = getFeatureResponse?.features?.[0]?.geometry?.type
+  }
+
+
+  return { dataServiceType, acceptedFormats, mapServiceVersion, bbox, wmsServiceUrl, featureType }
 }
 export async function getLayerProperties(capabilities, layerObject) {
   const mapServiceType = checkMapServiceType(layerObject.url)

--- a/src/lib/get-capabilities.js
+++ b/src/lib/get-capabilities.js
@@ -307,7 +307,7 @@ async function readWmtsCapabilitiesProperties(capabilities, layerObject) {
     map(getTagContent),
     uniq,
   )()
-console.log('acceptedFormats', acceptedFormats)
+
  const bbox = pipe(
   () => [ ...capabilities.querySelectorAll('Layer') ],
   filter(el => {

--- a/src/lib/get-feature.js
+++ b/src/lib/get-feature.js
@@ -1,9 +1,8 @@
 import buildGeoServerUrl from './build-geoserver-url'
 import { createWfsDownloadFilter } from './download-helpers'
 
-export default async function getFeature ({ url, layer, coordinates }) {
-  
-  const filter = createWfsDownloadFilter([], coordinates)
+export default async function getFeature ({ url, layer, coordinates, count }) {
+  const filter = coordinates ? createWfsDownloadFilter([], coordinates) : null
 
   const geoServerUrl = await buildGeoServerUrl({
     url,
@@ -13,7 +12,8 @@ export default async function getFeature ({ url, layer, coordinates }) {
     srs: 'EPSG:4326',
     typeName: layer,
     query_layers: layer,
-    filter,
+    ...(filter && { filter }),
+    ...(count != null && { count }),
   })
 
   return fetch(geoServerUrl)

--- a/src/lib/json-2-html-table.js
+++ b/src/lib/json-2-html-table.js
@@ -1,24 +1,30 @@
-export default function (layerName, json) {
-  const rows = json[0]
-  const properties = Object.keys(rows)
-
-  let htmlRows = properties
+function buildSection (title, properties) {
+  const htmlRows = Object.keys(properties)
     .map((property) => {
       return `<tr>
                 <td style="font-weight:bold; width: 33%; overflow-wrap: break-word; vertical-align: top;"> ${ property }:</td>
-                <td style="width: 67%; overflow-wrap: break-word; vertical-align: top;"> ${ rows[property] }</td>
+                <td style="width: 67%; overflow-wrap: break-word; vertical-align: top;"> ${ properties[property] }</td>
             </tr>`
     })
     .join('')
 
-  //build the table
-  const table = `
-  <p style="position: fixed; top: 0; left: 0; height: 20px; width: inherit; font-weight:bold; text-align:center; background-color: white;">${ layerName }</p>
-	<table style="table-layout: fixed; margin-top: 20px; width: 100%;">
-		<tbody>
-			${ htmlRows }
-		<tbody>
-	<table>`
+  return `
+  <div class="map-layer-info-section">
+    <p style="position: sticky; top: 0; height: 20px; width: 100%; font-weight:bold; text-align:center; background-color: white; z-index: 1;">${ title }</p>
+    <table style="table-layout: fixed; margin-top: 4px; width: 100%;">
+      <tbody>
+        ${ htmlRows }
+      </tbody>
+    </table>
+  </div>`
+}
 
-  return table
+export function buildCombinedPopup (sections) {
+  return sections
+    .map(({ title, properties }) => buildSection(title, properties))
+    .join('')
+}
+
+export default function (layerName, json) {
+  return buildCombinedPopup([ { title: layerName, properties: json[0] } ])
 }

--- a/src/store/modules/map/index.js
+++ b/src/store/modules/map/index.js
@@ -172,11 +172,15 @@ export default {
 
       layersToAdd.forEach((layer) => {
         getMapServicesCapabilities(layer.url)
+        //In the getLayerProperties based on the wms or wmts ending of the url we send the get
+        // capabilities request to the server. In the response we get the properties of the layer.
           .then(capabilities => getLayerProperties(capabilities, layer))
           .then((properties) => {
             commit('ADD_ACTIVE_FLATTENED_LAYER', { ...layer, ...properties } )
-            // commit('ADD_MAPBOX_LAYER',buildMapboxLayer({ ...layer, ...properties }))
+            //wms and wmts raster layers are using the buildMapboxLayer 
+            commit('ADD_MAPBOX_LAYER',buildMapboxLayer({ ...layer, ...properties }))
             if (properties.featureType) {
+              // if in the properties there is a featureType then we have a vector tiled layer. 
               commit('ADD_MAPBOX_LAYER', buildWmtsVectorLayer({ ...layer, ...properties, id: `${ layer.id }-vector` }))
             }
           },
@@ -200,6 +204,7 @@ export default {
       layers.forEach(layer => {
         commit('REMOVE_ACTIVE_FLATTENED_LAYER', { layer })
         commit('REMOVE_MAPBOX_LAYER', layer.id)
+        commit('REMOVE_MAPBOX_LAYER', layer.layer.split(':')[1])
       })
     },
   

--- a/src/store/modules/map/index.js
+++ b/src/store/modules/map/index.js
@@ -4,6 +4,7 @@ import buildMapboxLayer from '~/lib/build-mapbox-layer'
 import addFilterAttributesToLayer from '~/lib/add-filter-attributes-to-layer'
 import { getMapServicesCapabilities, getLayerProperties } from '~/lib/get-capabilities'
 import { NETHERLANDS_MAP_CENTER, NETHERLANDS_MAP_ZOOM } from '~/lib/constants'
+import buildWmtsVectorLayer from '~/lib/build-wmts-vector-layer'
 
 
 export default {
@@ -170,11 +171,14 @@ export default {
       const layersToAdd = difference(layers, state.activeFlattenedLayers)
 
       layersToAdd.forEach((layer) => {
-        getMapServicesCapabilities(layer.url) 
+        getMapServicesCapabilities(layer.url)
           .then(capabilities => getLayerProperties(capabilities, layer))
           .then((properties) => {
             commit('ADD_ACTIVE_FLATTENED_LAYER', { ...layer, ...properties } )
-            commit('ADD_MAPBOX_LAYER',buildMapboxLayer({ ...layer, ...properties }))
+            // commit('ADD_MAPBOX_LAYER',buildMapboxLayer({ ...layer, ...properties }))
+            if (properties.featureType) {
+              commit('ADD_MAPBOX_LAYER', buildWmtsVectorLayer({ ...layer, ...properties, id: `${ layer.id }-vector` }))
+            }
           },
           )
       })


### PR DESCRIPTION
Summary

Adds clickable WMTS vector tile (MVT) layers and a combined map-click info popup for all active layers.

- Detect MVT layers via GetCapabilities (application/vnd.mapbox-vector-tile)

- Resolve geometry type via WFS GetFeature (count: 1) → featureType

- Add invisible Mapbox vector overlay (build-wmts-vector-layer.js) for queryRenderedFeatures

Refactor MapLayerInfo to handle all active layers:

- MVT: queryRenderedFeatures at click

- Raster: parallel GetFeatureInfo per layer

Single popup with one section per layer (stacking order); GRAY_INDEX → <layerName>_value

- Fix vector layer removal from Vuex/map state

- MapLayer: add hoverable cursor for vector layers; move click logic to MapLayerInfo

README: document map-click behaviour

Test plan

 

- [ ] Activate a WMTS MVT layer → click feature → popup shows attributes
- [ ] 
- [ ]  Activate a raster WMS/WMTS layer → click → GetFeatureInfo popup works
- [ ] 
- [ ]  Activate multiple layers (vector + raster) → single combined popup, correct stacking order
- [ ] 
- [ ]  Click empty area → no popup
- [ ] 
- [ ]  Toggle layer off → vector overlay removed from map
- [ ] 
- [ ]  Hover vector layer → pointer cursor
- [ ] 
- [ ]  Draw mode still disables info popup